### PR TITLE
Fix twitter oauth and discord login errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,10 @@ DISCORD_CLIENT_ID=your_discord_client_id
 DISCORD_CLIENT_SECRET=your_discord_client_secret
 TWITTER_CLIENT_ID=your_twitter_client_id
 TWITTER_CLIENT_SECRET=your_twitter_client_secret
-TWITTER_REDIRECT_URI=http://localhost:4000/api/users/auth/twitter/callback
-TWITTER_BIND_REDIRECT_URI=http://localhost:4000/api/users/bind-auth/twitter/callback
+TWITTER_REDIRECT_URI=http://127.0.0.1:4000/api/users/auth/twitter/callback
+TWITTER_BIND_REDIRECT_URI=http://127.0.0.1:4000/api/users/bind-auth/twitter/callback
+
+# 注意：Twitter OAuth 2.0 建議使用 127.0.0.1 而不是 localhost 避免回調問題
 
 # 電子郵件服務 (SendGrid)
 SENDGRID_API_KEY=your_sendgrid_api_key

--- a/config/passport.js
+++ b/config/passport.js
@@ -218,7 +218,21 @@ const initializeOAuthStrategies = () => {
                   login_method: 'google',
                   email_verified: !!profile.emails?.[0]?.verified,
                 })
-                await user.save()
+                
+                try {
+                  await user.save()
+                } catch (saveError) {
+                  // 處理 google_id 重複的情況
+                  if (saveError.code === 11000 && saveError.keyPattern?.google_id) {
+                    console.log('Google ID 已存在，查找現有用戶:', profile.id)
+                    user = await User.findOne({ google_id: profile.id })
+                    if (!user) {
+                      throw new Error(`Google ID ${profile.id} 已存在但無法找到對應用戶`)
+                    }
+                  } else {
+                    throw saveError
+                  }
+                }
               }
               return done(null, user)
             }
@@ -317,7 +331,21 @@ const initializeOAuthStrategies = () => {
                   login_method: 'facebook',
                   email_verified: !!profile.emails?.[0]?.verified,
                 })
-                await user.save()
+                
+                try {
+                  await user.save()
+                } catch (saveError) {
+                  // 處理 facebook_id 重複的情況
+                  if (saveError.code === 11000 && saveError.keyPattern?.facebook_id) {
+                    console.log('Facebook ID 已存在，查找現有用戶:', profile.id)
+                    user = await User.findOne({ facebook_id: profile.id })
+                    if (!user) {
+                      throw new Error(`Facebook ID ${profile.id} 已存在但無法找到對應用戶`)
+                    }
+                  } else {
+                    throw saveError
+                  }
+                }
               }
               return done(null, user)
             }
@@ -413,7 +441,24 @@ const initializeOAuthStrategies = () => {
                   login_method: 'discord',
                   email_verified: !!profile.verified,
                 })
-                await user.save()
+                
+                try {
+                  await user.save()
+                } catch (saveError) {
+                  // 處理 discord_id 重複的情況
+                  if (saveError.code === 11000 && saveError.keyPattern?.discord_id) {
+                    console.log('Discord ID 已存在，查找現有用戶:', profile.id)
+                    // 再次查找用戶，可能是併發請求導致的問題
+                    user = await User.findOne({ discord_id: profile.id })
+                    if (!user) {
+                      // 如果還是找不到，說明有其他問題
+                      throw new Error(`Discord ID ${profile.id} 已存在但無法找到對應用戶`)
+                    }
+                  } else {
+                    // 其他錯誤直接拋出
+                    throw saveError
+                  }
+                }
               }
               return done(null, user)
             }
@@ -455,7 +500,7 @@ const initializeOAuthStrategies = () => {
           clientSecret: process.env.TWITTER_CLIENT_SECRET,
           callbackURL: process.env.TWITTER_REDIRECT_URI,
           passReqToCallback: true,
-          scope: ['tweet.read', 'users.read'],
+          scope: ['tweet.read', 'users.read', 'offline.access'],
           pkce: true,
           userProfileURL: 'https://api.twitter.com/2/users/me',
           includeEmail: true,
@@ -517,7 +562,21 @@ const initializeOAuthStrategies = () => {
                   login_method: 'twitter',
                   email_verified: !!profile.emails?.[0]?.verified,
                 })
-                await user.save()
+                
+                try {
+                  await user.save()
+                } catch (saveError) {
+                  // 處理 twitter_id 重複的情況
+                  if (saveError.code === 11000 && saveError.keyPattern?.twitter_id) {
+                    console.log('Twitter ID 已存在，查找現有用戶:', profile.id)
+                    user = await User.findOne({ twitter_id: profile.id })
+                    if (!user) {
+                      throw new Error(`Twitter ID ${profile.id} 已存在但無法找到對應用戶`)
+                    }
+                  } else {
+                    throw saveError
+                  }
+                }
               }
               return done(null, user)
             }
@@ -537,7 +596,7 @@ const initializeOAuthStrategies = () => {
           clientSecret: process.env.TWITTER_CLIENT_SECRET,
           callbackURL: process.env.TWITTER_BIND_REDIRECT_URI || process.env.TWITTER_REDIRECT_URI,
           passReqToCallback: true,
-          scope: ['tweet.read', 'users.read'],
+          scope: ['tweet.read', 'users.read', 'offline.access'],
           pkce: true,
           userProfileURL: 'https://api.twitter.com/2/users/me',
           includeEmail: true,

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -1429,7 +1429,7 @@ router.get('/auth/twitter', (req, res, next) => {
     }
 
     passport.authenticate('twitter-oauth2', {
-      scope: ['tweet.read', 'users.read'],
+      scope: ['tweet.read', 'users.read', 'offline.access'],
       state: state,
     })(req, res, next)
   })
@@ -1440,7 +1440,7 @@ router.get(
   '/auth/twitter/callback',
   verifyOAuthState,
   passport.authenticate('twitter-oauth2', {
-    scope: ['tweet.read', 'users.read'],
+    scope: ['tweet.read', 'users.read', 'offline.access'],
     failureRedirect: `${getFrontendUrl()}/login?error=oauth_failed`,
   }),
   async (req, res) => {

--- a/test/oauth-tests/oauth-fix-verification.js
+++ b/test/oauth-tests/oauth-fix-verification.js
@@ -1,0 +1,157 @@
+import mongoose from 'mongoose'
+import User from '../../models/User.js'
+
+// 測試 Discord 重複用戶處理
+async function testDiscordDuplicateHandling() {
+  console.log('🧪 測試 Discord 重複用戶處理...')
+  
+  try {
+    // 模擬創建第一個用戶
+    const user1 = new User({
+      username: 'testuser001',
+      email: 'test1@example.com',
+      discord_id: '123456789',
+      display_name: 'Test User 1',
+      login_method: 'discord',
+      email_verified: true,
+    })
+    
+    await user1.save()
+    console.log('✅ 第一個 Discord 用戶創建成功')
+    
+    // 測試重複 discord_id 的處理
+    try {
+      const user2 = new User({
+        username: 'testuser002',
+        email: 'test2@example.com',
+        discord_id: '123456789', // 相同的 discord_id
+        display_name: 'Test User 2',
+        login_method: 'discord',
+        email_verified: true,
+      })
+      
+      await user2.save()
+      console.log('❌ 意外：重複的 discord_id 沒有被檢測到')
+    } catch (error) {
+      if (error.code === 11000) {
+        console.log('✅ 重複的 discord_id 被正確檢測並拋出錯誤')
+        console.log(`   錯誤碼: ${error.code}`)
+        console.log(`   錯誤訊息: ${error.message}`)
+      } else {
+        console.log('❌ 意外的錯誤類型:', error.message)
+      }
+    }
+    
+    // 清理測試數據
+    await User.deleteOne({ discord_id: '123456789' })
+    console.log('🧹 測試數據已清理')
+    
+  } catch (error) {
+    console.error('❌ Discord 測試失敗:', error.message)
+  }
+}
+
+// 測試 Twitter OAuth 環境配置
+function testTwitterOAuthConfig() {
+  console.log('\n🧪 檢查 Twitter OAuth 環境配置...')
+  
+  const requiredEnvVars = [
+    'TWITTER_CLIENT_ID',
+    'TWITTER_CLIENT_SECRET',
+    'TWITTER_REDIRECT_URI',
+    'TWITTER_BIND_REDIRECT_URI'
+  ]
+  
+  let allConfigured = true
+  
+  requiredEnvVars.forEach(envVar => {
+    if (process.env[envVar]) {
+      console.log(`✅ ${envVar}: 已配置`)
+      if (envVar.includes('REDIRECT_URI')) {
+        const uri = process.env[envVar]
+        if (uri.includes('localhost')) {
+          console.log(`⚠️  警告: ${envVar} 使用 localhost，建議改為 127.0.0.1`)
+          console.log(`   當前值: ${uri}`)
+          console.log(`   建議值: ${uri.replace('localhost', '127.0.0.1')}`)
+        } else if (uri.includes('127.0.0.1')) {
+          console.log(`✅ ${envVar} 正確使用 127.0.0.1`)
+        }
+      }
+    } else {
+      console.log(`❌ ${envVar}: 未配置`)
+      allConfigured = false
+    }
+  })
+  
+  if (allConfigured) {
+    console.log('✅ 所有 Twitter OAuth 環境變數已配置')
+  } else {
+    console.log('❌ 部分 Twitter OAuth 環境變數未配置')
+  }
+}
+
+// 測試數據庫連接
+async function testDatabaseConnection() {
+  console.log('🧪 測試數據庫連接...')
+  
+  try {
+    if (mongoose.connection.readyState === 1) {
+      console.log('✅ 數據庫已連接')
+      return true
+    } else {
+      console.log('❌ 數據庫未連接')
+      return false
+    }
+  } catch (error) {
+    console.error('❌ 數據庫連接測試失敗:', error.message)
+    return false
+  }
+}
+
+// 主測試函數
+async function runOAuthFixVerification() {
+  console.log('🚀 開始 OAuth 修復驗證測試\n')
+  
+  // 測試數據庫連接
+  const dbConnected = await testDatabaseConnection()
+  
+  if (dbConnected) {
+    // 測試 Discord 重複處理
+    await testDiscordDuplicateHandling()
+  }
+  
+  // 測試 Twitter 配置
+  testTwitterOAuthConfig()
+  
+  console.log('\n📋 測試完成報告:')
+  console.log('================')
+  console.log('1. Discord 重複用戶處理: 已實現')
+  console.log('2. Twitter OAuth 配置檢查: 完成')
+  console.log('3. 環境變數建議: 使用 127.0.0.1 而非 localhost')
+  console.log('\n🔧 如果仍有問題，請檢查:')
+  console.log('- Twitter 開發者平台的回調 URL 設定')
+  console.log('- Discord 應用程式的 OAuth2 設定')
+  console.log('- 確保所有環境變數正確配置')
+}
+
+// 如果直接執行此腳本
+if (import.meta.url === `file://${process.argv[1]}`) {
+  // 載入環境變數
+  if (process.env.NODE_ENV !== 'production') {
+    const { config } = await import('dotenv')
+    config()
+  }
+  
+  // 連接數據庫（如果還沒連接）
+  if (mongoose.connection.readyState === 0) {
+    const MONGO_URI = process.env.MONGO_URI || 'mongodb://localhost:27017/memedam'
+    await mongoose.connect(MONGO_URI)
+  }
+  
+  await runOAuthFixVerification()
+  
+  // 關閉數據庫連接
+  await mongoose.disconnect()
+}
+
+export { runOAuthFixVerification, testDiscordDuplicateHandling, testTwitterOAuthConfig }


### PR DESCRIPTION
Fixes Twitter OAuth failure and Discord duplicate login error.

Twitter OAuth 2.0 was failing due to `localhost` redirect URI issues and missing `offline.access` scope. Discord re-login caused a duplicate ID error because the `discord_id` field has a unique constraint; the fix now handles this by finding the existing user instead of creating a new one. Similar duplicate ID handling is applied to Google, Facebook, and Twitter for consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-c5bf4829-e1bf-43f3-a0e3-713240c2943b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c5bf4829-e1bf-43f3-a0e3-713240c2943b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

