### PR TITLE
Fix Twitter OAuth2 login by specifying client type

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,5 +55,6 @@ DISCORD_BIND_REDIRECT_URI=http://localhost:4000/api/users/bind-auth/discord/call
 # OAuth 配置 - Twitter
 TWITTER_CLIENT_ID=your_twitter_client_id
 TWITTER_CLIENT_SECRET=your_twitter_client_secret
+TWITTER_CLIENT_TYPE=confidential
 TWITTER_REDIRECT_URI=http://localhost:4000/api/users/auth/twitter/callback
 TWITTER_BIND_REDIRECT_URI=http://localhost:4000/api/users/bind-auth/twitter/callback

--- a/.env.production.example
+++ b/.env.production.example
@@ -44,6 +44,7 @@ DISCORD_BIND_REDIRECT_URI=https://api.memedam.com/api/users/bind-auth/discord/ca
 # Twitter OAuth 配置
 TWITTER_CLIENT_ID=your_twitter_client_id
 TWITTER_CLIENT_SECRET=your_twitter_client_secret
+TWITTER_CLIENT_TYPE=confidential
 TWITTER_REDIRECT_URI=https://api.memedam.com/api/users/auth/twitter/callback
 TWITTER_BIND_REDIRECT_URI=https://api.memedam.com/api/users/bind-auth/twitter/callback
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ DISCORD_CLIENT_ID=your_discord_client_id
 DISCORD_CLIENT_SECRET=your_discord_client_secret
 TWITTER_CLIENT_ID=your_twitter_client_id
 TWITTER_CLIENT_SECRET=your_twitter_client_secret
+TWITTER_CLIENT_TYPE=confidential # confidential or public, based on Twitter app settings
 TWITTER_REDIRECT_URI=http://127.0.0.1:4000/api/users/auth/twitter/callback
 TWITTER_BIND_REDIRECT_URI=http://127.0.0.1:4000/api/users/bind-auth/twitter/callback
 

--- a/config/passport.js
+++ b/config/passport.js
@@ -522,6 +522,7 @@ const initializeOAuthStrategies = () => {
         {
           clientID: process.env.TWITTER_CLIENT_ID,
           clientSecret: process.env.TWITTER_CLIENT_SECRET,
+          clientType: process.env.TWITTER_CLIENT_TYPE || 'confidential',
           callbackURL: process.env.TWITTER_REDIRECT_URI,
           passReqToCallback: true,
           scope: ['tweet.read', 'users.read', 'offline.access'],
@@ -635,6 +636,7 @@ const initializeOAuthStrategies = () => {
         {
           clientID: process.env.TWITTER_CLIENT_ID,
           clientSecret: process.env.TWITTER_CLIENT_SECRET,
+          clientType: process.env.TWITTER_CLIENT_TYPE || 'confidential',
           callbackURL: process.env.TWITTER_BIND_REDIRECT_URI || process.env.TWITTER_REDIRECT_URI,
           passReqToCallback: true,
           scope: ['tweet.read', 'users.read', 'offline.access'],

--- a/docs/oauth-fixes-summary.md
+++ b/docs/oauth-fixes-summary.md
@@ -158,6 +158,7 @@ passport.authenticate('discord', {
    # 確保以下環境變數已正確設置
    TWITTER_CLIENT_ID=your_twitter_client_id
    TWITTER_CLIENT_SECRET=your_twitter_client_secret
+   TWITTER_CLIENT_TYPE=confidential
    TWITTER_REDIRECT_URI=http://localhost:4000/api/users/auth/twitter/callback
    
    DISCORD_CLIENT_ID=your_discord_client_id

--- a/docs/user-docs/oauth-bind-integration.md
+++ b/docs/user-docs/oauth-bind-integration.md
@@ -127,6 +127,7 @@ DISCORD_BIND_REDIRECT_URI=http://localhost:4000/api/users/bind-auth/discord/call
 # Twitter OAuth
 TWITTER_CLIENT_ID=your-twitter-client-id
 TWITTER_CLIENT_SECRET=your-twitter-client-secret
+TWITTER_CLIENT_TYPE=confidential
 TWITTER_REDIRECT_URI=http://localhost:4000/api/users/auth/twitter/callback
 TWITTER_BIND_REDIRECT_URI=http://localhost:4000/api/users/bind-auth/twitter/callback
 ```

--- a/test/oauth-tests/oauth-fix-verification.js
+++ b/test/oauth-tests/oauth-fix-verification.js
@@ -40,12 +40,14 @@ async function testOAuthFixes() {
     const twitterClientId = process.env.TWITTER_CLIENT_ID
     const twitterClientSecret = process.env.TWITTER_CLIENT_SECRET
     const twitterRedirectUri = process.env.TWITTER_REDIRECT_URI
-    
+    const twitterClientType = process.env.TWITTER_CLIENT_TYPE
+
     console.log('Twitter Client ID:', twitterClientId ? '✅ 已設置' : '❌ 未設置')
     console.log('Twitter Client Secret:', twitterClientSecret ? '✅ 已設置' : '❌ 未設置')
     console.log('Twitter Redirect URI:', twitterRedirectUri || '❌ 未設置')
-    
-    if (twitterClientId && twitterClientSecret && twitterRedirectUri) {
+    console.log('Twitter Client Type:', twitterClientType || '❌ 未設置')
+
+    if (twitterClientId && twitterClientSecret && twitterRedirectUri && twitterClientType) {
       console.log('✅ Twitter OAuth 環境變數配置完整')
     } else {
       console.log('⚠️  Twitter OAuth 環境變數配置不完整')


### PR DESCRIPTION
## Summary
- set `clientType` for Twitter OAuth2 strategies to handle confidential apps
- document `TWITTER_CLIENT_TYPE` in env examples and docs
- extend OAuth verification script to check new variable

## Testing
- `npm test`
- `npm run lint` *(fails: 'followed_id' is not defined and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6899617f9bc8832394fa47a823243a03