### PR TITLE
Investigate and fix discord oauth 522 error

### DIFF
--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -35,10 +35,16 @@ const router = express.Router()
 
 // 取得前端 URL 的輔助函數
 const getFrontendUrl = () => {
-  return (
-    process.env.FRONTEND_URL ||
+  let frontendUrl = process.env.FRONTEND_URL ||
     (process.env.NODE_ENV === 'production' ? 'https://memedam.com' : 'http://localhost:5173')
-  )
+  
+  // 在生產環境強制使用 HTTPS 以避免 Cloudflare 522 錯誤
+  if (process.env.NODE_ENV === 'production' && frontendUrl.startsWith('http://')) {
+    frontendUrl = frontendUrl.replace('http://', 'https://')
+    console.warn(`生產環境強制將 HTTP 轉換為 HTTPS: ${frontendUrl}`)
+  }
+  
+  return frontendUrl
 }
 
 // 生成 OAuth state 參數


### PR DESCRIPTION
Force HTTPS for frontend URL in production to resolve Cloudflare 522 errors during Discord OAuth redirect.

---
<a href="https://cursor.com/background-agent?bcId=bc-57d3ac6f-9b11-4cf7-8386-b223edc30dfa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-57d3ac6f-9b11-4cf7-8386-b223edc30dfa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

