### PR TITLE
Check for existing twitter id on login

### DIFF
--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -1377,6 +1377,10 @@ router.get('/auth/discord', (req, res, next) => {
   console.log('  Generated state:', state)
   console.log('  Session ID:', req.sessionID)
 
+  // 清除 req.user 以確保這被視為登入流程而不是綁定流程
+  req.user = undefined
+  req.session.isBindingFlow = false
+
   // 強制保存 session 並等待完成
   req.session.save((err) => {
     if (err) {
@@ -1476,6 +1480,10 @@ router.get('/auth/twitter', (req, res, next) => {
   }
 
   req.session.oauthState = state
+
+  // 清除 req.user 以確保這被視為登入流程而不是綁定流程
+  req.user = undefined
+  req.session.isBindingFlow = false
 
   // 確保 session 被保存
   req.session.save((err) => {


### PR DESCRIPTION
Corrects Twitter and Discord OAuth login by distinguishing between login and account binding flows.

Previously, if a user had an active session (i.e., `req.user` was populated), Twitter and Discord OAuth strategies would incorrectly interpret subsequent logins as attempts to *bind* the social account to an existing user, leading to "ID already exists" errors. This PR ensures that these flows are correctly identified as logins, allowing existing users to sign in seamlessly.

---
<a href="https://cursor.com/background-agent?bcId=bc-693cba2d-538b-482f-a873-5cda9e41c5c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-693cba2d-538b-482f-a873-5cda9e41c5c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

