### PR TITLE
Fix log encoding and typo in index.js

### DIFF
--- a/utils/logger.js
+++ b/utils/logger.js
@@ -8,14 +8,32 @@ const logger = pino({
   level: process.env.LOG_LEVEL || 'info',
   base: undefined, // 移除 pid/hostname 噪音
   timestamp: pino.stdTimeFunctions.isoTime,
+  // 確保正確的編碼設置
+  serializers: pino.stdSerializers,
   transport: isDevelopment ? {
     target: 'pino-pretty',
     options: {
-      colorize: true,
+      colorize: process.stdout.isTTY, // 只在 TTY 環境啟用顏色
       translateTime: 'SYS:standard',
-      ignore: 'pid,hostname'
+      ignore: 'pid,hostname',
+      // 確保正確的編碼設置
+      singleLine: false,
+      hideObject: false,
+      // 禁用可能導致問題的 ANSI 轉義碼
+      colorizeObjects: false,
+      // 確保正確處理 Unicode 字符
+      messageFormat: '{msg}',
+      // 避免額外的格式化可能導致的編碼問題
+      sync: false
     }
-  } : undefined
+  } : {
+    // 生產環境使用簡單的 JSON 格式，避免編碼問題
+    target: 'pino/file',
+    options: {
+      destination: 1, // stdout
+      sync: false
+    }
+  }
 });
 
 // 設置全域 log 對象


### PR DESCRIPTION
Resolve log garbling and formatting issues by refining Pino configuration and removing redundant log middleware.

This PR addresses log encoding problems, removes the conflicting `morgan` middleware, and corrects `pino-pretty` colorization settings to eliminate garbled characters and extraneous ANSI escape codes in the logs.

---
<a href="https://cursor.com/background-agent?bcId=bc-a701695c-24fb-49fc-b88a-0458edcc27c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a701695c-24fb-49fc-b88a-0458edcc27c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

