### PR TITLE
Debug empty response and blocked network

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,17 +75,22 @@ const allowedOrigins = [
 app.use(
   helmet({
     crossOriginResourcePolicy: { policy: 'cross-origin' }, // 若有跨網域圖片/資源
+    crossOriginOpenerPolicy: { policy: 'unsafe-none' }, // 允許 OAuth 彈窗
+    crossOriginEmbedderPolicy: false, // 暫時禁用以避免 ORB 問題
     contentSecurityPolicy: {
       directives: {
         defaultSrc: ["'self'"],
         styleSrc: ["'self'", "'unsafe-inline'"],
-        scriptSrc: ["'self'"],
-        imgSrc: ["'self'", 'data:', 'https:'],
-        connectSrc: ["'self'", 'https:', 'wss:'],
-        fontSrc: ["'self'"],
+        scriptSrc: ["'self'", "'unsafe-inline'"], // OAuth 可能需要 inline scripts
+        imgSrc: ["'self'", 'data:', 'https:', 'blob:'], // 支援更多圖片來源
+        connectSrc: ["'self'", 'https:', 'wss:', '*.twitter.com', '*.x.com'], // 支援 Twitter API
+        fontSrc: ["'self'", 'data:'],
         objectSrc: ["'none'"],
         mediaSrc: ["'self'"],
-        frameSrc: ["'none'"],
+        frameSrc: ["'self'", '*.twitter.com', '*.x.com'], // 支援 Twitter OAuth 框架
+        frameAncestors: ["'none'"],
+        baseUri: ["'self'"],
+        formAction: ["'self'", '*.twitter.com', '*.x.com'], // 支援 Twitter OAuth 表單提交
       },
     },
   }),


### PR DESCRIPTION
Fix Twitter OAuth binding by resolving session serialization, token storage, and CSP issues.

The previous implementation failed due to incorrect session handling for OAuth 1.0a tokens, improper serialization of the OAuth profile, and overly strict Helmet CSP rules. These issues collectively caused `ERR_EMPTY_RESPONSE` and `ERR_BLOCKED_BY_ORB` errors during the Twitter binding callback.

---
<a href="https://cursor.com/background-agent?bcId=bc-576e6c29-95ab-4052-83eb-f30c9e760a81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-576e6c29-95ab-4052-83eb-f30c9e760a81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

