### PR TITLE
fix: ensure trusted ObjectId queries

### DIFF
--- a/utils/collaborativeFiltering.js
+++ b/utils/collaborativeFiltering.js
@@ -948,7 +948,7 @@ export const buildSocialGraph = async (userIds = []) => {
       // 分離查詢：先查詢 follower_id - 使用 mongoose.trusted
       const followerFollows = await Follow.find(
         mongoose.trusted({
-          follower_id: { $in: safeUserIds },
+          follower_id: mongoose.trusted({ $in: safeUserIds }),
           status: 'active',
         }),
       )
@@ -960,7 +960,7 @@ export const buildSocialGraph = async (userIds = []) => {
       // 再查詢 following_id - 使用 mongoose.trusted
       const followingFollows = await Follow.find(
         mongoose.trusted({
-          following_id: { $in: safeUserIds },
+          following_id: mongoose.trusted({ $in: safeUserIds }),
           status: 'active',
         }),
       )

--- a/utils/socialScoreCalculator.js
+++ b/utils/socialScoreCalculator.js
@@ -234,7 +234,7 @@ export const buildSocialGraph = async (userIds = []) => {
     // 分離查詢：先查詢 follower_id - 使用 mongoose.trusted
     const followerFollows = await Follow.find(
       mongoose.trusted({
-        follower_id: { $in: safeUserIds },
+        follower_id: mongoose.trusted({ $in: safeUserIds }),
         status: 'active',
       }),
     )
@@ -242,7 +242,7 @@ export const buildSocialGraph = async (userIds = []) => {
     // 再查詢 following_id - 使用 mongoose.trusted
     const followingFollows = await Follow.find(
       mongoose.trusted({
-        following_id: { $in: safeUserIds },
+        following_id: mongoose.trusted({ $in: safeUserIds }),
         status: 'active',
       }),
     )


### PR DESCRIPTION
## Summary
- wrap follower/following `$in` queries with `mongoose.trusted` to prevent ObjectId cast errors

## Testing
- `npm test` *(fails: 43 failed, 2 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b7458c03948323ab7c3f623ecac340