### PR TITLE
Fix cache parsing and privacy consent middleware

### DIFF
--- a/middleware/privacyConsent.js
+++ b/middleware/privacyConsent.js
@@ -1,5 +1,7 @@
 import PrivacyConsent from '../models/PrivacyConsent.js'
 import { logger } from '../utils/logger.js'
+import mongoose from 'mongoose'
+import crypto from 'crypto'
 
 /**
  * 隱私同意檢查 Middleware
@@ -26,7 +28,6 @@ const getSessionId = (req) => {
   if (req.headers['x-session-id']) return req.headers['x-session-id']
   if (req.cookies?.sessionId) return req.cookies.sessionId
 
-  const crypto = require('crypto')
   return crypto.randomBytes(32).toString('hex')
 }
 
@@ -41,7 +42,7 @@ const checkPrivacyConsent = async (req) => {
     if (req.user && req.user._id) {
       try {
         // 確保 userId 是 ObjectId 類型
-        const { ObjectId } = require('mongoose').Types
+        const { ObjectId } = mongoose.Types
         let userId = req.user._id
 
         // 檢查 userId 是否已經是 ObjectId
@@ -77,7 +78,7 @@ const checkPrivacyConsent = async (req) => {
         // 如果已登入且找到的同意記錄是基於 session、且尚未綁定 userId，則進行遷移
         if (req.user && req.user._id && consent && !consent.userId) {
           try {
-            const { ObjectId } = require('mongoose').Types
+            const { ObjectId } = mongoose.Types
             let migratedUserId = req.user._id
 
             // 檢查 userId 是否已經是 ObjectId

--- a/utils/socialScoreCalculator.js
+++ b/utils/socialScoreCalculator.js
@@ -167,10 +167,12 @@ class SocialScoreVersionedCacheProcessor {
 
         if (cachedData !== null) {
           try {
-            const parsedData = JSON.parse(cachedData)
+            // redisCache.get 可能已解析 JSON，因此僅在字串時解析
+            const parsedData =
+              typeof cachedData === 'string' ? JSON.parse(cachedData) : cachedData
 
             // 如果快取包含版本資訊且版本匹配，返回快取數據
-            if (parsedData.version && parsedData.version === currentVersion) {
+            if (parsedData && parsedData.version === currentVersion) {
               return {
                 data: parsedData.data,
                 version: parsedData.version,
@@ -178,7 +180,10 @@ class SocialScoreVersionedCacheProcessor {
               }
             }
           } catch (parseError) {
-            console.warn(`快取數據解析失敗 (${cacheKey}), 將重新獲取數據:`, parseError.message)
+            console.warn(
+              `快取數據解析失敗 (${cacheKey}), 將重新獲取數據:`,
+              parseError.message,
+            )
             // 刪除無效的快取數據
             await this.redis.del(cacheKey)
           }


### PR DESCRIPTION
## Summary
- avoid double JSON parsing when reading versioned cache so social graph caching works
- replace CommonJS requires in privacy consent middleware with ES module imports and crypto/mongoose usage

## Testing
- `npm test` *(fails: 53 failed, 2 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4ed9c92c83238cd4dfa46a7776c9