### PR TITLE
Fix privacy consent middleware attachment error

### DIFF
--- a/models/PrivacyConsent.js
+++ b/models/PrivacyConsent.js
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose'
+import { logger } from '../utils/logger.js'
 
 const privacyConsentSchema = new mongoose.Schema({
   // User association
@@ -101,8 +102,6 @@ privacyConsentSchema.methods.toJSON = function () {
 
 // Static methods
 privacyConsentSchema.statics.findActiveByUserId = function (userId) {
-  const { logger } = require('../utils/logger.js')
-
   // 確保 userId 是 ObjectId 類型
   let queryUserId = userId
   if (userId && typeof userId === 'string') {


### PR DESCRIPTION
Fixes privacy consent middleware errors by resolving ESM/CommonJS `require` mix-up.

The application, running in an ES Module environment, was using `require()` calls within `middleware/privacyConsent.js` and `models/PrivacyConsent.js` for `mongoose`, `crypto`, and `logger`. This caused runtime errors, leading the `attachPrivacyConsent` middleware to consistently fail and log "附加隱私同意資訊失敗" (Failed to attach privacy consent information) for every API request. The changes replace these `require()` calls with `import` statements to ensure correct module loading.

---
<a href="https://cursor.com/background-agent?bcId=bc-c640cd4a-7a0b-40b4-bc9a-ae4df16ae0b6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c640cd4a-7a0b-40b4-bc9a-ae4df16ae0b6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

