### PR TITLE
Changes from background agent bc-f049a841-30ce-4fb9-920a-ccdf01ad438e

### DIFF
--- a/utils/collaborativeFiltering.js
+++ b/utils/collaborativeFiltering.js
@@ -138,7 +138,8 @@ class CollaborativeVersionedCacheProcessor {
 
         if (cachedData !== null) {
           try {
-            const parsedData = JSON.parse(cachedData)
+            const parsedData =
+              typeof cachedData === 'string' ? JSON.parse(cachedData) : cachedData
 
             // 如果快取包含版本資訊且版本匹配，返回快取數據
             if (parsedData.version && parsedData.version === currentVersion) {
@@ -183,8 +184,9 @@ class CollaborativeVersionedCacheProcessor {
           const cached = await this.redis.get(cacheKey)
           if (cached !== null) {
             try {
+              const parsed = typeof cached === 'string' ? JSON.parse(cached) : cached
               return {
-                data: JSON.parse(cached),
+                data: parsed,
                 version: '1.0.0',
                 fromCache: true,
               }

--- a/utils/contentBased.js
+++ b/utils/contentBased.js
@@ -110,7 +110,8 @@ class ContentBasedVersionedCacheProcessor {
 
         if (cachedData !== null) {
           try {
-            const parsedData = JSON.parse(cachedData)
+            const parsedData =
+              typeof cachedData === 'string' ? JSON.parse(cachedData) : cachedData
 
             // 如果快取包含版本資訊且版本匹配，返回快取數據
             if (parsedData.version && parsedData.version === currentVersion) {
@@ -155,8 +156,9 @@ class ContentBasedVersionedCacheProcessor {
           const cached = await this.redis.get(cacheKey)
           if (cached !== null) {
             try {
+              const parsed = typeof cached === 'string' ? JSON.parse(cached) : cached
               return {
-                data: JSON.parse(cached),
+                data: parsed,
                 version: '1.0.0',
                 fromCache: true,
               }

--- a/utils/hotScore.js
+++ b/utils/hotScore.js
@@ -104,7 +104,8 @@ class HotScoreVersionedCacheProcessor {
 
         if (cachedData !== null) {
           try {
-            const parsedData = JSON.parse(cachedData)
+            const parsedData =
+              typeof cachedData === 'string' ? JSON.parse(cachedData) : cachedData
 
             // 如果快取包含版本資訊且版本匹配，返回快取數據
             if (parsedData.version && parsedData.version === currentVersion) {
@@ -149,8 +150,9 @@ class HotScoreVersionedCacheProcessor {
           const cached = await this.redis.get(cacheKey)
           if (cached !== null) {
             try {
+              const parsed = typeof cached === 'string' ? JSON.parse(cached) : cached
               return {
-                data: JSON.parse(cached),
+                data: parsed,
                 version: '1.0.0',
                 fromCache: true,
               }

--- a/utils/mixedRecommendation.js
+++ b/utils/mixedRecommendation.js
@@ -117,7 +117,8 @@ class VersionedCacheProcessor {
 
         if (cachedData !== null) {
           try {
-            const parsedData = JSON.parse(cachedData)
+            const parsedData =
+              typeof cachedData === 'string' ? JSON.parse(cachedData) : cachedData
 
             // 如果快取包含版本資訊且版本匹配，返回快取數據
             if (parsedData.version && parsedData.version === currentVersion) {


### PR DESCRIPTION
Fix Redis cache JSON parsing to prevent "[object Object]" errors from already-parsed values.

Unconditionally calling `JSON.parse` on values retrieved from Redis can lead to errors if the Redis client has already parsed the value into an object, or if the value is not a valid JSON string. This change adds a type check to ensure `JSON.parse` is only applied when the cached value is a string, preventing "is not valid JSON" errors and unnecessary cache re-computations.

---
<a href="https://cursor.com/background-agent?bcId=bc-f049a841-30ce-4fb9-920a-ccdf01ad438e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f049a841-30ce-4fb9-920a-ccdf01ad438e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

