### PR TITLE
Handle socialSimilarUsers not iterable error

### DIFF
--- a/utils/collaborativeFiltering.js
+++ b/utils/collaborativeFiltering.js
@@ -76,7 +76,7 @@ const safeJsonStringify = (data) => {
 import { handleQueryError } from './errorHandler.js'
 import cacheVersionManager from './cacheVersionManager.js'
 import redisCache from '../config/redis.js'
-import mongoose from 'mongoose'
+// 重複匯入移除（已於檔案頂部匯入）
 
 /**
  * 資料庫連線健康檢查
@@ -946,7 +946,7 @@ export const getCollaborativeFilteringRecommendations = async (targetUserId, opt
         }
 
         // 找到相似用戶
-        const similarUsers = findSimilarUsers(
+        const similarUsers = await findSimilarUsers(
           targetUserIdObj.toString(),
           interactionMatrix,
           minSimilarity,
@@ -1799,7 +1799,7 @@ export const getSocialCollaborativeFilteringRecommendations = async (
         }
 
         // 找到社交相似用戶
-        const socialSimilarUsers = findSocialSimilarUsers(
+        const socialSimilarUsers = await findSocialSimilarUsers(
           targetUserIdObj.toString(),
           socialGraph,
           minSimilarity,
@@ -2076,7 +2076,7 @@ export const getSocialCollaborativeFilteringStats = async (userId) => {
     const userInteractions = interactionMatrix[userIdStr] || {}
     const userSocialData = socialGraph[userIdStr] || {}
 
-    const socialSimilarUsers = findSocialSimilarUsers(userIdStr, socialGraph, 0.1, 100)
+    const socialSimilarUsers = await findSocialSimilarUsers(userIdStr, socialGraph, 0.1, 100)
 
     return {
       user_id: userId,


### PR DESCRIPTION
Add `await` to `findSimilarUsers` and `findSocialSimilarUsers` calls to resolve 'is not iterable' errors and remove a duplicate `mongoose` import.

The error "socialSimilarUsers is not iterable" occurred because `findSimilarUsers` and `findSocialSimilarUsers` are async functions returning Promises, but their results were consumed directly without `await`, leading to a Promise being treated as an iterable object.

---
<a href="https://cursor.com/background-agent?bcId=bc-65c2edb5-6ef5-4319-84c0-a11353ccd726">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-65c2edb5-6ef5-4319-84c0-a11353ccd726">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

