### PR TITLE
Handle social similar users not iterable error

### DIFF
--- a/utils/collaborativeFiltering.js
+++ b/utils/collaborativeFiltering.js
@@ -5,6 +5,8 @@
  */
 
 import mongoose from 'mongoose'
+// 移除重複匯入
+// 重複匯入移除
 import Like from '../models/Like.js'
 import Collection from '../models/Collection.js'
 import Comment from '../models/Comment.js'
@@ -76,7 +78,7 @@ const safeJsonStringify = (data) => {
 import { handleQueryError } from './errorHandler.js'
 import cacheVersionManager from './cacheVersionManager.js'
 import redisCache from '../config/redis.js'
-import mongoose from 'mongoose'
+ 
 
 /**
  * 資料庫連線健康檢查
@@ -946,7 +948,7 @@ export const getCollaborativeFilteringRecommendations = async (targetUserId, opt
         }
 
         // 找到相似用戶
-        const similarUsers = findSimilarUsers(
+        const similarUsers = await findSimilarUsers(
           targetUserIdObj.toString(),
           interactionMatrix,
           minSimilarity,
@@ -1799,7 +1801,7 @@ export const getSocialCollaborativeFilteringRecommendations = async (
         }
 
         // 找到社交相似用戶
-        const socialSimilarUsers = findSocialSimilarUsers(
+        const socialSimilarUsers = await findSocialSimilarUsers(
           targetUserIdObj.toString(),
           socialGraph,
           minSimilarity,
@@ -2076,7 +2078,7 @@ export const getSocialCollaborativeFilteringStats = async (userId) => {
     const userInteractions = interactionMatrix[userIdStr] || {}
     const userSocialData = socialGraph[userIdStr] || {}
 
-    const socialSimilarUsers = findSocialSimilarUsers(userIdStr, socialGraph, 0.1, 100)
+    const socialSimilarUsers = await findSocialSimilarUsers(userIdStr, socialGraph, 0.1, 100)
 
     return {
       user_id: userId,


### PR DESCRIPTION
Add `await` to asynchronous function calls in collaborative filtering to fix "socialSimilarUsers is not iterable" errors and remove duplicate `mongoose` import.

The `findSimilarUsers` and `findSocialSimilarUsers` functions return Promises. Without `await`, their results were being treated as iterable objects, leading to a `TypeError: socialSimilarUsers is not iterable` and a 500 status code for the social collaborative filtering recommendation API. This fix ensures the Promises resolve before their results are used.

---
<a href="https://cursor.com/background-agent?bcId=bc-aa5da88b-bd92-44fd-9298-ae3fd6a02ad8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aa5da88b-bd92-44fd-9298-ae3fd6a02ad8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

