### PR TITLE
Fix remaining seo route integration test errors

### DIFF
--- a/routes/seoRoutes.js
+++ b/routes/seoRoutes.js
@@ -723,7 +723,7 @@ router.post('/health-check', token, seoController.runSEOHealthCheck)
  *             schema:
  *               $ref: '#/components/schemas/Error'
  */
-router.get('/dashboard', token, seoController.getSEODashboard)
+router.get('/dashboard', token, seoController.getSEODashboard.bind(seoController))
 
 /**
  * @swagger


### PR DESCRIPTION
Fixes `seo-routes.test.js` errors by correctly binding mocked dependencies, bypassing auth middleware, and ensuring `this` context for the `getSEODashboard` controller.

The integration tests for SEO routes were failing due to several issues: `vi.mock` instances for `seoMonitor` and `redisCache` were not correctly assigned, leading to `undefined` errors; the `auth` middleware was not mocked, causing authentication failures; and the `getSEODashboard` controller method was called without `this` context, resulting in 500 errors. This PR addresses these issues to make the tests pass.

---
<a href="https://cursor.com/background-agent?bcId=bc-9520bfb8-60ed-4e18-8fa5-da5ef61ae5ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9520bfb8-60ed-4e18-8fa5-da5ef61ae5ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

